### PR TITLE
feat:  Enhance GET status to Check Keycloak Connectivity #37

### DIFF
--- a/api/routes/status_routes/get.py
+++ b/api/routes/status_routes/get.py
@@ -1,33 +1,43 @@
 from fastapi import APIRouter, HTTPException
 from api.services import status_services
+from api.services.keycloak_services.get_admin_token import get_admin_token
 
 router = APIRouter()
 
 @router.get(
     "/",
     response_model=str,
-    summary="Check CKAN status",
-    description="Check if the CKAN server is active and reachable."
+    summary="Check system status",
+    description="Check if the CKAN and Keycloak servers are active and reachable."
 )
-async def get_ckan_status():
+async def get_status():
     """
-    Endpoint to check if CKAN is active and reachable.
+    Endpoint to check if CKAN and Keycloak are active and reachable.
 
     Returns
     -------
     str
-        A message confirming if CKAN is active.
+        A message confirming if CKAN and Keycloak are active.
 
     Raises
     ------
     HTTPException
-        If there is an error connecting to CKAN, an HTTPException is raised with a detailed message.
+        If there is an error connecting to CKAN or Keycloak, an HTTPException is raised with a detailed message.
     """
     try:
-        is_active = status_services.check_ckan_status()
-        if is_active:
-            return "CKAN is active and reachable."
+        ckan_is_active = status_services.check_ckan_status()
+        try:
+            keycloak_is_active = get_admin_token()
+        except Exception as e:
+            keycloak_is_active = False
+        if ckan_is_active and keycloak_is_active:
+            return "CKAN and Keycloak are active and reachable."
         else:
-            raise HTTPException(status_code=503, detail="CKAN is not reachable.")
+            if ckan_is_active and keycloak_is_active:
+                raise HTTPException(status_code=503, detail="Keycloak is not reachable.")
+            elif keycloak_is_active:
+                raise HTTPException(status_code=503, detail="CKAN is not reachable.")
+            else:
+                raise HTTPException(status_code=503, detail="CKAN and Keycloak are not reachable.")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -3,15 +3,29 @@ from fastapi.templating import Jinja2Templates
 
 from api.config import swagger_settings
 from api.services import status_services
+from api.services.keycloak_services.get_admin_token import get_admin_token
 
 def index(request: Request):
     templates = Jinja2Templates(directory="api/templates")
     
     # Verifica el estado de CKAN
     try:
-        ckan_status = "CKAN is active" if status_services.check_ckan_status() else "CKAN is not reachable"
+        ckan_is_active = status_services.check_ckan_status()
+        try:
+            keycloak_is_active = get_admin_token()
+        except Exception as e:
+            keycloak_is_active = False
+        if ckan_is_active and keycloak_is_active:
+            status = "CKAN and Keycloak are active and reachable."
+        else:
+            if ckan_is_active and keycloak_is_active:
+                status = "CKAN is active, but Keycloak is not reachable."
+            elif keycloak_is_active:
+                status = "Keycloak is active, CKAN is not reachable."
+            else:
+                status = "CKAN and Keycloak are not reachable."
     except Exception as e:
-        ckan_status = "CKAN not found."
+        status = "CKAN and Keycloak are not reachable."
     
     return templates.TemplateResponse(
         request=request,
@@ -20,6 +34,6 @@ def index(request: Request):
             "title": swagger_settings.swagger_title,
             "version": swagger_settings.swagger_version,
             "docs_url": f"{request.base_url}docs",
-            "ckan_status": ckan_status
+            "status": status
         }
     )

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -7,6 +7,6 @@
 <body>
     <h1>{{ title }} v{{ version }}</h1>
     <a href="{{ docs_url }}">View Swagger Docs</a>
-    <p>{{ ckan_status }}</p> <!-- Añadir el estado de CKAN aquí -->
+    <p>{{ status }}</p>
 </body>
 </html>


### PR DESCRIPTION
The previous status endpoint only checked CKAN. Now, it also verifies that Keycloak is active by requesting the admin Keycloak token.