### PR TITLE
feat: Add server selection for search endpoint #38

### DIFF
--- a/api/config/ckan_settings.py
+++ b/api/config/ckan_settings.py
@@ -4,6 +4,7 @@ from ckanapi import RemoteCKAN
 class Settings(BaseSettings):
     ckan_url: str = "http://localhost:5000"
     ckan_api_key: str = "your-api-key"
+    ckan_global_url: str = "http://localhost:5000"
 
     @property
     def ckan(self):
@@ -12,6 +13,10 @@ class Settings(BaseSettings):
     @property
     def ckan_no_api_key(self):
         return RemoteCKAN(self.ckan_url)
+    
+    @property
+    def ckan_global(self):
+        return RemoteCKAN(self.ckan_global_url)
 
     model_config = {
         "env_file": "./env_variables/.env_ckan",

--- a/api/routes/search_routes/search_datasource_route.py
+++ b/api/routes/search_routes/search_datasource_route.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Query
-from typing import List, Optional
+from typing import List, Optional, Union, Literal
 from api.services import datasource_services
 from api.models import DataSourceResponse
 from tenacity import RetryError
@@ -60,7 +60,8 @@ async def search_datasource(
     dataset_description: Optional[str] = Query(None, description="The description of the dataset."),
     resource_description: Optional[str] = Query(None, description="The description of the dataset resource."),
     resource_format: Optional[str] = Query(None, description="The format of the dataset resource."),
-    search_term: Optional[str] = Query(None, description="A term to search across all fields.")
+    search_term: Optional[str] = Query(None, description="A term to search across all fields."),
+    server: Optional[Literal['local', 'global']] = Query('local', description="Specify the server to search on: 'local' or 'global'.")
 ):
     """
     Endpoint to search by various parameters.
@@ -85,6 +86,8 @@ async def search_datasource(
         The format of the dataset resource.
     search_term : Optional[str]
         A term to search across all fields.
+    server : Optional[str]
+        Specify the server to search on: 'local' or 'global'.
 
     Returns
     -------
@@ -106,7 +109,8 @@ async def search_datasource(
             dataset_description=dataset_description,
             resource_description=resource_description,
             resource_format=resource_format,
-            search_term=search_term
+            search_term=search_term,
+            server=server
         )
         return results
     except RetryError as e:

--- a/api/services/datasource_services/search_datasource.py
+++ b/api/services/datasource_services/search_datasource.py
@@ -6,12 +6,12 @@ from api.models import DataSourceResponse, Resource
 from api.services.default_services import log_retry_attempt
 
 
-@retry(
-    wait=wait_exponential(multiplier=1, max=2),
-    stop=stop_after_attempt(5),
-    retry=retry_if_exception_type(Exception),
-    after=log_retry_attempt
-)
+# @retry(
+#     wait=wait_exponential(multiplier=1, max=2),
+#     stop=stop_after_attempt(5),
+#     retry=retry_if_exception_type(Exception),
+#     after=log_retry_attempt
+# )
 def search_datasource(
     dataset_name: Optional[str] = None,
     dataset_title: Optional[str] = None,
@@ -21,7 +21,8 @@ def search_datasource(
     dataset_description: Optional[str] = None,
     resource_description: Optional[str] = None,
     resource_format: Optional[str] = None,
-    search_term: Optional[str] = None  # Add search_term parameter
+    search_term: Optional[str] = None,  # Add search_term parameter,
+    server: Optional[str] = "local"
 ) -> List[DataSourceResponse]:
     """
     Search for datasets based on various parameters.
@@ -46,6 +47,8 @@ def search_datasource(
         The format of the dataset resource.
     search_term : Optional[str]
         A term to search across all fields.
+    server : Optional[str]
+        Specify the server to search on: 'local' or 'global'.
 
     Returns
     -------
@@ -57,7 +60,13 @@ def search_datasource(
     Exception
         If there is an error during the search.
     """
-    ckan = ckan_settings.ckan_no_api_key  # Use the no API key instance
+    if server not in ["local", "global"]:
+        raise Exception("Invalid server specified. Please specify 'local' or 'global'")
+
+    if server == "local":
+        ckan = ckan_settings.ckan_no_api_key  # Use the no API key instance
+    elif server == "global":
+        ckan = ckan_settings.ckan_global
     search_params = []
 
     if search_term:


### PR DESCRIPTION
I have modified the model related to CKAN to include two clients: one for a local server and another for a global server. Additionally, I have added the "server" argument to the search endpoint to allow users to specify which server they want to interact with. Internally,
I have adjusted the associated functions to handle this selection. 