### PR TITLE
Add tests for Kafka resource creation and deletion, and fix dataset deletion issue

### DIFF
--- a/tests/test_post_and_delete_kafka.py
+++ b/tests/test_post_and_delete_kafka.py
@@ -24,10 +24,10 @@ def test_create_and_delete_kafka_resource_with_org():
         "title": "Test Organization",
         "description": "This is a test organization."
     }
-    
+
     create_org_response = client.post("/organization", json=org_payload, headers=headers)
     assert create_org_response.status_code == 201
-    
+
     create_org_data = create_org_response.json()
     assert "id" in create_org_data
 
@@ -53,10 +53,10 @@ def test_create_and_delete_kafka_resource_with_org():
             "info_key": "info"
         }
     }
-    
+
     create_kafka_response = client.post("/kafka", json=kafka_payload, headers=headers)
     assert create_kafka_response.status_code == 201
-    
+
     create_kafka_data = create_kafka_response.json()
     assert "id" in create_kafka_data
 


### PR DESCRIPTION
This pull request introduces comprehensive tests for the creation and deletion of Kafka resources and the associated organization. Key improvements include:

- Creation of a Kafka resource under a newly created organization.
- Successful deletion of the Kafka resource using its dataset ID.
- Removal of the organization after the Kafka resource is deleted.
- Fix for the dataset deletion function to correctly handle dataset IDs and ensure proper cleanup.
- The test ensures that all components are created and cleaned up properly, maintaining system integrity.