### PR TITLE
Extend tests for create_url to support all file types

### DIFF
--- a/api/routes/register_routes/post_url.py
+++ b/api/routes/register_routes/post_url.py
@@ -3,7 +3,6 @@ from api.services.url_services.add_url import add_url
 from api.models.urlrequest_model import URLRequest
 from tenacity import RetryError
 from typing import Dict, Any
-
 from api.services.keycloak_services.get_current_user import get_current_user
 
 router = APIRouter()
@@ -13,78 +12,82 @@ router = APIRouter()
     response_model=dict,
     status_code=status.HTTP_201_CREATED,
     summary="Add a new URL resource",
-    description="""
-Create a new URL resource in CKAN.
-
-### Common Fields for All File Types
-- **resource_name**: The unique name of the resource to be created.
-- **resource_title**: The title of the resource to be created.
-- **owner_org**: The ID of the organization to which the resource belongs.
-- **resource_url**: The URL of the resource to be added.
-- **file_type**: The type of the file (`stream`, `CSV`, `TXT`, `JSON`, `NetCDF`).
-- **notes**: Additional notes about the resource (optional).
-- **extras**: Additional metadata to be added to the resource package as extras (optional).
-- **mapping**: Mapping information for the dataset (optional).
-- **processing**: Processing information for the dataset, which varies based on the `file_type`.
-
-### File Type-Specific Processing Information
-
-1. **Stream**
-    ```json
-    "processing": {
-        "refresh_rate": "5 seconds",
-        "data_key": "results"
-    }
-    ```
-    - **refresh_rate**: The refresh rate for the data stream.
-    - **data_key**: The key for the response data in the JSON file.
-
-2. **CSV**
-    ```json
-    "processing": {
-        "delimiter": ",",
-        "header_line": 1,
-        "start_line": 2,
-        "comment_char": "#"
-    }
-    ```
-    - **delimiter**: The delimiter used in the CSV file.
-    - **header_line**: The line number of the header in the CSV file.
-    - **start_line**: The line number where the data starts in the CSV file.
-    - **comment_char**: The character used for comments in the CSV file (optional).
-
-3. **TXT**
-    ```json
-    "processing": {
-        "delimiter": "\t",
-        "header_line": 1,
-        "start_line": 2
-    }
-    ```
-    - **delimiter**: The delimiter used in the TXT file.
-    - **header_line**: The line number of the header in the TXT file.
-    - **start_line**: The line number where the data starts in the TXT file.
-
-4. **JSON**
-    ```json
-    "processing": {
-        "info_key": "count",
-        "additional_key": "",
-        "data_key": "results"
-    }
-    ```
-    - **info_key**: The key for additional information in the JSON file (optional).
-    - **additional_key**: An additional key in the JSON file (optional).
-    - **data_key**: The key for the response data in the JSON file.
-
-5. **NetCDF**
-    ```json
-    "processing": {
-        "group": "group_name"
-    }
-    ```
-    - **group**: The group within the NetCDF file (optional).
-""",
+    description=(
+        "Create a new URL resource in CKAN.\n\n"
+        "### Common Fields for All File Types\n"
+        "- **resource_name**: The unique name of the resource to be created.\n"
+        "- **resource_title**: The title of the resource to be created.\n"
+        "- **owner_org**: The ID of the organization to which the resource "
+        "belongs.\n"
+        "- **resource_url**: The URL of the resource to be added.\n"
+        "- **file_type**: The type of the file (`stream`, `CSV`, `TXT`, "
+        "`JSON`, `NetCDF`).\n"
+        "- **notes**: Additional notes about the resource (optional).\n"
+        "- **extras**: Additional metadata to be added to the resource "
+        "package as extras (optional).\n"
+        "- **mapping**: Mapping information for the dataset (optional).\n"
+        "- **processing**: Processing information for the dataset, which "
+        "varies based on the `file_type`.\n\n"
+        "### File Type-Specific Processing Information\n"
+        "1. **Stream**\n"
+        "    ```json\n"
+        '    "processing": {\n'
+        '        "refresh_rate": "5 seconds",\n'
+        '        "data_key": "results"\n'
+        "    }\n"
+        "    ```\n"
+        "    - **refresh_rate**: The refresh rate for the data stream.\n"
+        "    - **data_key**: The key for the response data in the JSON file.\n\n"
+        "2. **CSV**\n"
+        "    ```json\n"
+        '    "processing": {\n'
+        '        "delimiter": ",",\n'
+        '        "header_line": 1,\n'
+        '        "start_line": 2,\n'
+        '        "comment_char": "#"\n'
+        "    }\n"
+        "    ```\n"
+        "    - **delimiter**: The delimiter used in the CSV file.\n"
+        "    - **header_line**: The line number of the header in the CSV "
+        "file.\n"
+        "    - **start_line**: The line number where the data starts in the "
+        "CSV file.\n"
+        "    - **comment_char**: The character used for comments in the CSV "
+        "file (optional).\n\n"
+        "3. **TXT**\n"
+        "    ```json\n"
+        '    "processing": {\n'
+        '        "delimiter": "\\t",\n'
+        '        "header_line": 1,\n'
+        '        "start_line": 2\n'
+        "    }\n"
+        "    ```\n"
+        "    - **delimiter**: The delimiter used in the TXT file.\n"
+        "    - **header_line**: The line number of the header in the TXT "
+        "file.\n"
+        "    - **start_line**: The line number where the data starts in the "
+        "TXT file.\n\n"
+        "4. **JSON**\n"
+        "    ```json\n"
+        '    "processing": {\n'
+        '        "info_key": "count",\n'
+        '        "additional_key": "",\n'
+        '        "data_key": "results"\n'
+        "    }\n"
+        "    ```\n"
+        "    - **info_key**: The key for additional information in the JSON "
+        "file (optional).\n"
+        "    - **additional_key**: An additional key in the JSON file "
+        "(optional).\n"
+        "    - **data_key**: The key for the response data in the JSON file.\n\n"
+        "5. **NetCDF**\n"
+        "    ```json\n"
+        '    "processing": {\n'
+        '        "group": "group_name"\n'
+        "    }\n"
+        "    ```\n"
+        "    - **group**: The group within the NetCDF file (optional).\n"
+    ),
     responses={
         201: {
             "description": "Resource created successfully",
@@ -98,7 +101,11 @@ Create a new URL resource in CKAN.
             "description": "Bad Request",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Error creating resource: <error message>"}
+                    "example": {
+                        "detail": (
+                            "Error creating resource: <error message>"
+                        )
+                    }
                 }
             }
         }
@@ -106,24 +113,28 @@ Create a new URL resource in CKAN.
 )
 async def create_url_resource(
     data: URLRequest,
-    _: Dict[str, Any] = Depends(get_current_user)):
+    _: Dict[str, Any] = Depends(get_current_user)
+):
     """
     Add a URL resource to CKAN.
 
     Parameters
     ----------
     data : URLRequest
-        An object containing all the required parameters for creating a URL resource.
+        An object containing all the required parameters for creating a 
+        URL resource.
 
     Returns
     -------
     dict
-        A dictionary containing the ID of the created resource if successful.
+        A dictionary containing the ID of the created resource if 
+        successful.
 
     Raises
     ------
     HTTPException
-        If there is an error creating the resource, an HTTPException is raised with a detailed message.
+        If there is an error creating the resource, an HTTPException is 
+        raised with a detailed message.
     """
     try:
         resource_id = add_url(

--- a/tests/test_create_url.py
+++ b/tests/test_create_url.py
@@ -1,0 +1,87 @@
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+from api.config import keycloak_settings
+import random
+import string
+
+client = TestClient(app)
+
+def generate_random_name(prefix="test"):
+    return f"{prefix}_" + ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+
+@pytest.mark.parametrize("file_type,processing", [
+    ("stream", {"refresh_rate": "5 seconds", "data_key": "results"}),
+    ("CSV", {"delimiter": ",", "header_line": 1, "start_line": 2, "comment_char": "#"}),
+    ("TXT", {"delimiter": "\t", "header_line": 1, "start_line": 2}),
+    ("JSON", {"info_key": "count", "additional_key": "", "data_key": "results"}),
+    ("NetCDF", {"group": "group_name"}),
+])
+def test_create_and_delete_url_resource_with_org(file_type, processing):
+    org_name = generate_random_name("org")
+    resource_name = generate_random_name("url_resource")
+    
+    headers = {
+        "Authorization": f"Bearer {keycloak_settings.test_token}"
+    }
+    
+    # Step 1: Create the organization
+    org_payload = {
+        "name": org_name,
+        "title": "Test Organization",
+        "description": "This is a test organization."
+    }
+    
+    create_org_response = client.post("/organization", json=org_payload, headers=headers)
+    assert create_org_response.status_code == 201
+    
+    create_org_data = create_org_response.json()
+    assert "id" in create_org_data
+
+    # Step 2: Create the URL resource under the new organization
+    url_payload = {
+        "resource_name": resource_name,
+        "resource_title": f"{file_type} Resource Test",
+        "owner_org": org_name,
+        "resource_url": "http://example.com/resource",
+        "file_type": file_type,
+        "notes": "This is a test URL resource.",
+        "extras": {
+            "key1": "value1",
+            "key2": "value2"
+        },
+        "mapping": {
+            "field1": "mapping1",
+            "field2": "mapping2"
+        },
+        "processing": processing
+    }
+    
+    create_url_response = client.post("/url", json=url_payload, headers=headers)
+    assert create_url_response.status_code == 201
+    
+    create_url_data = create_url_response.json()
+    assert "id" in create_url_data
+
+    # Verify the ID of the created resource
+    resource_id = create_url_data["id"]
+    print(f"Resource created with ID: {resource_id}")
+
+    # Step 3: Delete the URL resource
+    delete_response = client.delete(f"/{resource_id}", headers=headers)
+    
+    # Print the error detail if the deletion fails
+    if delete_response.status_code != 200:
+        print(f"Error deleting resource: {delete_response.json()}")
+    
+    assert delete_response.status_code == 200
+    
+    delete_data = delete_response.json()
+    assert "deleted successfully" in delete_data["message"]
+
+    # Step 4: Delete the organization
+    delete_org_response = client.delete(f"/organization/{org_name}", headers=headers)
+    assert delete_org_response.status_code == 200
+    
+    delete_org_data = delete_org_response.json()
+    assert delete_org_data["message"] == "Organization deleted successfully"


### PR DESCRIPTION
This pull request extends the existing tests for the `create_url` endpoint to ensure it handles all supported file types correctly. The following improvements have been made:

- Added parametrized tests to validate the creation and deletion of URL resources for the following file types: `stream`, `CSV`, `TXT`, `JSON`, and `NetCDF`.
- Confirmed that each resource type is created successfully and can be deleted without errors.
- Ensured that the associated organization is also deleted after the resource is removed.
