### PR TITLE
Add tests for S3 resource creation and deletion, and refactor create_s3_resource endpoint to follow PEP 8

### DIFF
--- a/api/routes/register_routes/post_s3.py
+++ b/api/routes/register_routes/post_s3.py
@@ -3,7 +3,6 @@ from api.services.s3_services.add_s3 import add_s3
 from api.models.s3request_model import S3Request
 from tenacity import RetryError
 from typing import Dict, Any
-
 from api.services.keycloak_services.get_current_user import get_current_user
 
 router = APIRouter()
@@ -19,7 +18,9 @@ router = APIRouter()
             "description": "Resource created successfully",
             "content": {
                 "application/json": {
-                    "example": {"id": "12345678-abcd-efgh-ijkl-1234567890ab"}
+                    "example": {
+                        "id": "12345678-abcd-efgh-ijkl-1234567890ab"
+                    }
                 }
             }
         },
@@ -27,7 +28,9 @@ router = APIRouter()
             "description": "Bad Request",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Error creating resource: <error message>"}
+                    "example": {
+                        "detail": "Error creating resource: <error message>"
+                    }
                 }
             }
         }
@@ -35,24 +38,28 @@ router = APIRouter()
 )
 async def create_s3_resource(
     data: S3Request,
-    _: Dict[str, Any] = Depends(get_current_user)):
+    _: Dict[str, Any] = Depends(get_current_user)
+):
     """
     Add an S3 resource to CKAN.
 
     Parameters
     ----------
     data : S3Request
-        An object containing all the required parameters for creating an S3 resource.
+        An object containing all the required parameters for creating an 
+        S3 resource.
 
     Returns
     -------
     dict
-        A dictionary containing the ID of the created resource if successful.
+        A dictionary containing the ID of the created resource if 
+        successful.
 
     Raises
     ------
     HTTPException
-        If there is an error creating the resource, an HTTPException is raised with a detailed message.
+        If there is an error creating the resource, an HTTPException is 
+        raised with a detailed message.
     """
     try:
         resource_id = add_s3(

--- a/tests/test_create_s3.py
+++ b/tests/test_create_s3.py
@@ -1,0 +1,74 @@
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+from api.config import keycloak_settings
+import random
+import string
+
+client = TestClient(app)
+
+def generate_random_name(prefix="test"):
+    return f"{prefix}_" + ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+
+def test_create_and_delete_s3_resource_with_org():
+    org_name = generate_random_name("org")
+    resource_name = generate_random_name("s3_resource")
+    
+    headers = {
+        "Authorization": f"Bearer {keycloak_settings.test_token}"
+    }
+    
+    # Step 1: Create the organization
+    org_payload = {
+        "name": org_name,
+        "title": "Test Organization",
+        "description": "This is a test organization."
+    }
+    
+    create_org_response = client.post("/organization", json=org_payload, headers=headers)
+    assert create_org_response.status_code == 201
+    
+    create_org_data = create_org_response.json()
+    assert "id" in create_org_data
+
+    # Step 2: Create the S3 resource under the new organization
+    s3_payload = {
+        "resource_name": resource_name,
+        "resource_title": "S3 Resource Test",
+        "owner_org": org_name,
+        "resource_s3": "http://example.com/resource",
+        "notes": "This is a test S3 resource.",
+        "extras": {
+            "key1": "value1",
+            "key2": "value2"
+        }
+    }
+    
+    create_s3_response = client.post("/s3", json=s3_payload, headers=headers)
+    assert create_s3_response.status_code == 201
+    
+    create_s3_data = create_s3_response.json()
+    assert "id" in create_s3_data
+
+    # Verify the ID of the created resource
+    resource_id = create_s3_data["id"]
+    print(f"Resource created with ID: {resource_id}")
+
+    # Step 3: Delete the S3 resource
+    delete_response = client.delete(f"/{resource_id}", headers=headers)
+    
+    # Print the error detail if the deletion fails
+    if delete_response.status_code != 200:
+        print(f"Error deleting resource: {delete_response.json()}")
+    
+    assert delete_response.status_code == 200
+    
+    delete_data = delete_response.json()
+    assert "deleted successfully" in delete_data["message"]
+
+    # Step 4: Delete the organization
+    delete_org_response = client.delete(f"/organization/{org_name}", headers=headers)
+    assert delete_org_response.status_code == 200
+    
+    delete_org_data = delete_org_response.json()
+    assert delete_org_data["message"] == "Organization deleted successfully"


### PR DESCRIPTION
This pull request introduces a test for the creation and deletion of an S3 resource within CKAN. It covers:

- Creation of an S3 resource under a newly created organization.
- Successful deletion of the S3 resource and subsequent deletion of the organization.
- Refactor of the `create_s3_resource` endpoint to comply with PEP 8 standards.
