### PR TITLE
Add tests for search_datasource endpoint including resource creation and deletion

### DIFF
--- a/api/routes/search_routes/search_datasource_route.py
+++ b/api/routes/search_routes/search_datasource_route.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Query
-from typing import List, Optional, Union, Literal
+from typing import List, Optional, Literal
 from api.services import datasource_services
 from api.models import DataSourceResponse
 from tenacity import RetryError
@@ -45,7 +45,9 @@ router = APIRouter()
             "description": "Bad Request",
             "content": {
                 "application/json": {
-                    "example": {"detail": "Error message explaining the bad request"}
+                    "example": {
+                        "detail": "Error message explaining the bad request"
+                    }
                 }
             }
         }
@@ -61,7 +63,9 @@ async def search_datasource(
     resource_description: Optional[str] = Query(None, description="The description of the dataset resource."),
     resource_format: Optional[str] = Query(None, description="The format of the dataset resource."),
     search_term: Optional[str] = Query(None, description="A term to search across all fields."),
-    server: Optional[Literal['local', 'global']] = Query('local', description="Specify the server to search on: 'local' or 'global'.")
+    server: Optional[Literal['local', 'global']] = Query(
+        'local', description="Specify the server to search on: 'local' or 'global'."
+    )
 ):
     """
     Endpoint to search by various parameters.
@@ -97,7 +101,8 @@ async def search_datasource(
     Raises
     ------
     HTTPException
-        If there is an error searching for the datasets, an HTTPException is raised with a detailed message.
+        If there is an error searching for the datasets, an HTTPException is 
+        raised with a detailed message.
     """
     try:
         results = await datasource_services.search_datasource(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,86 @@
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+from api.config import keycloak_settings
+import random
+import string
+
+client = TestClient(app)
+
+def generate_random_name(prefix="test"):
+    return f"{prefix}_" + ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+
+def test_create_search_and_delete_datasource_with_org():
+    org_name = generate_random_name("org")
+    dataset_name = generate_random_name("dataset")
+    resource_name = generate_random_name("resource")
+    
+    headers = {
+        "Authorization": f"Bearer {keycloak_settings.test_token}"
+    }
+    
+    # Step 1: Create the organization
+    org_payload = {
+        "name": org_name,
+        "title": "Test Organization",
+        "description": "This is a test organization."
+    }
+    
+    create_org_response = client.post("/organization", json=org_payload, headers=headers)
+    assert create_org_response.status_code == 201
+    
+    create_org_data = create_org_response.json()
+    assert "id" in create_org_data
+
+    # Step 2: Create the dataset with resource
+    dataset_payload = {
+        "resource_name": resource_name,
+        "resource_title": "Test Resource Title",
+        "owner_org": org_name,
+        "resource_s3": "http://example.com/resource",
+        "notes": "This is a test resource.",
+        "extras": {
+            "key1": "value1",
+            "key2": "value2"
+        }
+    }
+    
+    create_dataset_response = client.post("/s3", json=dataset_payload, headers=headers)
+    assert create_dataset_response.status_code == 201
+    
+    create_dataset_data = create_dataset_response.json()
+    assert "id" in create_dataset_data
+
+    # Step 3: Search for the dataset using different parameters
+    search_params = {
+        "dataset_name": resource_name,
+        "dataset_title": "Test Resource Title",
+        "owner_org": org_name,
+        "resource_url": "http://example.com/resource",
+        "resource_name": resource_name,
+        "dataset_description": "This is a test dataset.",
+        "resource_description": "This is a test resource.",
+        "resource_format": "CSV",
+        "search_term": "test",
+        "server": "local"
+    }
+    
+    search_response = client.get("/search", params=search_params, headers=headers)
+    assert search_response.status_code == 200
+    
+    search_results = search_response.json()
+    assert len(search_results) > 0
+
+    # Step 4: Delete the dataset
+    delete_response = client.delete(f"/{resource_name}", headers=headers)
+    assert delete_response.status_code == 200
+    
+    delete_data = delete_response.json()
+    assert "deleted successfully" in delete_data["message"]
+
+    # Step 5: Delete the organization
+    delete_org_response = client.delete(f"/organization/{org_name}", headers=headers)
+    assert delete_org_response.status_code == 200
+    
+    delete_org_data = delete_org_response.json()
+    assert delete_org_data["message"] == "Organization deleted successfully"


### PR DESCRIPTION
This pull request introduces a comprehensive test for the `search_datasource` endpoint. The test covers:

- Creation of an organization and a dataset with associated resources.
- Search for the dataset using all possible parameters in the `search_datasource` endpoint.
- Successful deletion of the dataset and the associated organization.
- Refactor of the `search_datasource` endpoint to comply with PEP 8 standards.
