### PR TITLE
feat: Add POP configuration to control route visibility, issue #89

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Using Keycloak, the API manages user authentication and authorization, providing
 ### 4. URL Ingestion and Management
 The API supports data ingestion through URLs, allowing for dynamic management and updating of external data sources.
 
+### 5. Point of Presence (POP) Configuration
+The sciDX API can be configured for use as a Point of Presence (POP) within the NDP project. When the POP configuration is enabled, specific API routes, such as those related to stream management, are hidden to tailor the API's functionality for POP deployments.
+
 ## Installation
 
 For detailed instructions on installing, configuring, and accessing the sciDX API, please see the [Installation Guide](docs/installation.md).

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
     swagger_version: str = "0.1.0"
+    pop: bool = False
 
     model_config = {
         "env_file": "./env_variables/.env_swagger",

--- a/api/routes/register_routes/__init__.py
+++ b/api/routes/register_routes/__init__.py
@@ -6,6 +6,7 @@ from .post_organization import router as post_organization_router
 from .post_url import router as post_url_router
 from .post_s3 import router as post_s3_router
 from .post_stream import router as post_stream_router
+from ...config import swagger_settings
 
 router = APIRouter()
 
@@ -14,5 +15,6 @@ router.include_router(post_kafka_datasoruce_router)
 router.include_router(post_organization_router)
 router.include_router(post_url_router)
 router.include_router(post_s3_router)
-router.include_router(post_stream_router)
+if not swagger_settings.pop:
+    router.include_router(post_stream_router)
 

--- a/api/routes/search_routes/__init__.py
+++ b/api/routes/search_routes/__init__.py
@@ -3,9 +3,11 @@ from fastapi import APIRouter
 from .search_datasource_route import router as get_router
 from .list_organizations_route import router as list_organizations_router
 from .get_stream import router as get_stream_router
+from ...config import swagger_settings
 
 router = APIRouter()
 
 router.include_router(get_router)
 router.include_router(list_organizations_router)
-router.include_router(get_stream_router)
+if not swagger_settings.pop:
+    router.include_router(get_stream_router)

--- a/env_variables/.env_swagger.example
+++ b/env_variables/.env_swagger.example
@@ -9,3 +9,8 @@ SWAGGER_DESCRIPTION=API documentation
 # Version of the API being documented.
 # This version number helps users understand which version of the API they are interacting with.
 SWAGGER_VERSION=0.1.0
+
+# Toggle to control the visibility of specific routes in the API documentation.
+# When set to "True", the POST /stream and GET /stream routes will be hidden.
+# This is useful for configuring the API as a Point of Presence (POP) for NDP.
+POP=False

--- a/tests/test_hide_pop.py
+++ b/tests/test_hide_pop.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from api.main import app
+from api.config import swagger_settings, keycloak_settings
+
+client = TestClient(app)
+
+def test_pop_configuration():
+    headers = {
+        "Authorization": f"Bearer {keycloak_settings.test_token}"
+    }
+
+    if swagger_settings.pop:  # Check if POP is True
+        # Test POST /stream endpoint is hidden
+        post_stream_response = client.post("/stream", json={"data": "test"}, headers=headers)
+        assert post_stream_response.status_code == 404
+
+        # Test GET /stream endpoint is hidden
+        get_stream_response = client.get("/stream", headers=headers)
+        assert get_stream_response.status_code == 404
+    else:  # POP is False
+        # Test POST /stream endpoint is available
+        post_stream_response = client.post("/stream", json={"data": "test"}, headers=headers)
+        assert post_stream_response.status_code != 404
+        
+        # Test GET /stream endpoint is available
+        get_stream_response = client.get("/stream", headers=headers)
+        assert get_stream_response.status_code != 404


### PR DESCRIPTION
This pull request introduces a new `POP` configuration setting to the sciDX API, allowing for conditional visibility of specific routes based on the `POP` environment variable.

**Key Changes:**
- **POP Configuration:**
  - Added `POP` environment variable to `.env_swagger`, defaulting to `False`.
  - Integrated the `POP` setting in `swagger_settings.py` to control route visibility.
  
- **Route Visibility:**
  - When `POP` is `True`, the `POST /stream` and `GET /stream` endpoints are hidden from the API.
  - When `POP` is `False`, all routes, including `POST /stream` and `GET /stream`, are visible.

- **Tests:**
  - Added tests to verify the correct behavior of route visibility based on the `POP` setting.

**Purpose:**
This feature enables the API to be configured for use as a Point of Presence (POP) within the NDP project, where only a subset of the API's routes is needed.