### PR TITLE
Tests fix and extension

### DIFF
--- a/api/services/url_services/add_url.py
+++ b/api/services/url_services/add_url.py
@@ -64,7 +64,7 @@ def add_url(
         "file_type":file_type
     }
 
-    if dxspaces_settings.registration_methods['url']:
+    if dxspaces_settings.registration_methods['url'] and file_type == "NetCDF":
         dxspaces = dxspaces_settings.dxspaces
         staging_params = {'url': resource_url}
         staging_handle = dxspaces.Register('url', resource_name, staging_params)

--- a/tests/test_create_s3.py
+++ b/tests/test_create_s3.py
@@ -55,7 +55,7 @@ def test_create_and_delete_s3_resource_with_org():
     print(f"Resource created with ID: {resource_id}")
 
     # Step 3: Delete the S3 resource
-    delete_response = client.delete(f"/{resource_id}", headers=headers)
+    delete_response = client.delete(f"/resource/{resource_name}", headers=headers)
     
     # Print the error detail if the deletion fails
     if delete_response.status_code != 200:

--- a/tests/test_create_url.py
+++ b/tests/test_create_url.py
@@ -24,14 +24,22 @@ def test_create_and_delete_url_resource_with_org(file_type, processing):
     headers = {
         "Authorization": f"Bearer {keycloak_settings.test_username}"
     }
-    
+   
+    resource_url_dict = {
+            "stream": "http://example.com/resource",
+            "CSV": "http://example.com/resource.csv",
+            "TXT": "http://example.com/resource.txt",
+            "JSON": "http://example.com/resource.json",
+            "NetCDF": "http://example.com/resource.nc"
+    }
+
     # Step 1: Create the organization
     org_payload = {
         "name": org_name,
         "title": "Test Organization",
         "description": "This is a test organization."
     }
-    
+   
     create_org_response = client.post("/organization", json=org_payload, headers=headers)
     assert create_org_response.status_code == 201
     
@@ -43,7 +51,7 @@ def test_create_and_delete_url_resource_with_org(file_type, processing):
         "resource_name": resource_name,
         "resource_title": f"{file_type} Resource Test",
         "owner_org": org_name,
-        "resource_url": "http://example.com/resource",
+        "resource_url": resource_url_dict[file_type],
         "file_type": file_type,
         "notes": "This is a test URL resource.",
         "extras": {
@@ -68,7 +76,7 @@ def test_create_and_delete_url_resource_with_org(file_type, processing):
     print(f"Resource created with ID: {resource_id}")
 
     # Step 3: Delete the URL resource
-    delete_response = client.delete(f"/{resource_id}", headers=headers)
+    delete_response = client.delete(f"/resource/{resource_name}", headers=headers)
     
     # Print the error detail if the deletion fails
     if delete_response.status_code != 200:

--- a/tests/test_post_and_delete_kafka.py
+++ b/tests/test_post_and_delete_kafka.py
@@ -65,7 +65,7 @@ def test_create_and_delete_kafka_resource_with_org():
     print(f"Dataset created with ID: {dataset_id}")
 
     # Step 3: Delete the Kafka resource
-    delete_response = client.delete(f"/{dataset_id}", headers=headers)
+    delete_response = client.delete(f"/resource/{dataset_name}", headers=headers)
     
     # Print the error detail if the deletion fails
     if delete_response.status_code != 200:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,7 @@ from api.main import app
 from api.config import keycloak_settings
 import random
 import string
+import json
 
 client = TestClient(app)
 
@@ -74,6 +75,137 @@ def test_create_search_and_delete_datasource_with_org():
     # Step 4: Delete the dataset
     delete_response = client.delete(f"/resource/{resource_name}", headers=headers)
     assert delete_response.status_code == 200
+    
+    delete_data = delete_response.json()
+    assert "deleted successfully" in delete_data["message"]
+
+    # Step 5: Delete the organization
+    delete_org_response = client.delete(f"/organization/{org_name}", headers=headers)
+    assert delete_org_response.status_code == 200
+    
+    delete_org_data = delete_org_response.json()
+    assert delete_org_data["message"] == "Organization deleted successfully"
+
+def test_create_search_and_delete_timestamped_datasource_with_org():
+    org_name = generate_random_name("org")
+    dataset_name = generate_random_name("dataset")
+    resource_name = generate_random_name("resource")
+    
+    headers = {
+        "Authorization": f"Bearer {keycloak_settings.test_username}"
+    }
+    
+    # Step 1: Create the organization
+    org_payload = {
+        "name": org_name,
+        "title": "Test Organization",
+        "description": "This is a test organization."
+    }
+    
+    create_org_response = client.post("/organization", json=org_payload, headers=headers)
+    assert create_org_response.status_code == 201
+    
+    create_org_data = create_org_response.json()
+    assert "id" in create_org_data
+    # Step 2: Create datasets with resource
+    test_resources = [
+        (generate_random_name(), "http://example.com/resource1.nc", "2024-10-03T10:30"),
+        (generate_random_name(), "http://example.com/resource2.nc", "2024-10-03T11:30"),
+        (generate_random_name(), "http://example.com/resource3.nc", "2024-10-03T12:30")
+    ]
+    extra_key = generate_random_name()
+    extra_val = generate_random_name()
+    for (resource_name, resource_url, timestamp) in test_resources:
+        url_payload = {
+            "resource_name": resource_name,
+            "resource_title": "Timestamped Resource Test",
+            "owner_org": org_name,
+            "resource_url": resource_url,
+            "file_type": "NetCDF",
+            "extras": {
+                extra_key: extra_val,
+                "timestamp": timestamp
+            }
+        }
+        print(url_payload)
+        create_url_response = client.post("/url", json=url_payload, headers=headers)
+        print(create_url_response.json())
+        assert create_url_response.status_code == 201
+    
+        create_dataset_data = create_url_response.json()
+        assert "id" in create_dataset_data
+
+    # Step 3: Search for the dataset using different parameters
+
+    # Step 3a: all results come back
+    search_params = {
+        "filter_list": [f"{extra_key}:{extra_val}"]
+    }
+
+    search_response = client.post("/search", json=search_params, headers=headers)
+    assert search_response.status_code == 200
+    
+    search_results = search_response.json()
+    assert len(search_results) == 3
+
+    # Step 3b: first result later than 11:15 come back
+    search_params = {
+        "filter_list": [f"{extra_key}:{extra_val}"],
+        "timestamp": ">2024-10-03T11:15"
+    }
+
+    search_response = client.post("/search", json=search_params, headers=headers)
+    assert search_response.status_code == 200
+    
+    search_results = search_response.json()
+    assert len(search_results) == 1
+
+    timestep = search_results[0]["extras"]["timestamp"]
+    assert timestep == "2024-10-03T11:30"
+
+    # Step 3c: first result earlier than 11:15 come back
+    search_params = {
+        "filter_list": [f"{extra_key}:{extra_val}"],
+        "timestamp": "<2024-10-03T11:15"
+    }
+
+    search_response = client.post("/search", json=search_params, headers=headers)
+    assert search_response.status_code == 200
+    
+    search_results = search_response.json()
+    assert len(search_results) == 1
+
+    timestep = search_results[0]["extras"]["timestamp"]
+    assert timestep == "2024-10-03T10:30"
+
+    # Step 3d: all result later than 11:15 come back
+    search_params = {
+        "filter_list": [f"{extra_key}:{extra_val}"],
+        "timestamp": "2024-10-03T11:15/"
+    }
+
+    search_response = client.post("/search", json=search_params, headers=headers)
+    assert search_response.status_code == 200
+    
+    search_results = search_response.json()
+    assert len(search_results) == 2
+
+    # Step 3e: all result earlier than 11:15 come back
+    search_params = {
+        "filter_list": [f"{extra_key}:{extra_val}"],
+        "timestamp": "/2024-10-03T11:15"
+    }
+
+    search_response = client.post("/search", json=search_params, headers=headers)
+    assert search_response.status_code == 200
+    
+    search_results = search_response.json()
+    assert len(search_results) == 1
+    
+    # Step 4: Delete the datasets
+    for (resource_name, *_) in test_resources:
+        delete_response = client.delete(f"/resource/{resource_name}", headers=headers)
+        assert delete_response.status_code == 200
     
     delete_data = delete_response.json()
     assert "deleted successfully" in delete_data["message"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,7 +4,6 @@ from api.main import app
 from api.config import keycloak_settings
 import random
 import string
-import json
 
 client = TestClient(app)
 
@@ -127,9 +126,7 @@ def test_create_search_and_delete_timestamped_datasource_with_org():
                 "timestamp": timestamp
             }
         }
-        print(url_payload)
         create_url_response = client.post("/url", json=url_payload, headers=headers)
-        print(create_url_response.json())
         assert create_url_response.status_code == 201
     
         create_dataset_data = create_url_response.json()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -59,8 +59,8 @@ def test_create_search_and_delete_datasource_with_org():
         "resource_url": "http://example.com/resource",
         "resource_name": resource_name,
         "dataset_description": "This is a test dataset.",
-        "resource_description": "This is a test resource.",
-        "resource_format": "CSV",
+        "resource_description": "Resource pointing to http://example.com/resource",
+        "resource_format": "s3",
         "search_term": "test",
         "server": "local"
     }
@@ -72,7 +72,7 @@ def test_create_search_and_delete_datasource_with_org():
     assert len(search_results) > 0
 
     # Step 4: Delete the dataset
-    delete_response = client.delete(f"/{resource_name}", headers=headers)
+    delete_response = client.delete(f"/resource/{resource_name}", headers=headers)
     assert delete_response.status_code == 200
     
     delete_data = delete_response.json()

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -12,7 +12,6 @@ def test_login_for_access_token_success():
         data={"username": keycloak_settings.test_username, "password": keycloak_settings.test_password}
     )
     assert response.status_code == 200
-    assert response.json()["access_token"] == keycloak_settings.test_username
     assert response.json()["token_type"] == "bearer"
 
 


### PR DESCRIPTION
This PR makes some modifications to testing:

1. Fix resource deletes. I'm assuming the delete endpoint changed from `/{id}` to `/resource/{name}` at some point. I have updated the tests.
2. Put file extensions on the test urls that are relevant to `file_type`. For the moment, DataSpaces registration detects the file type by file extension so NetCDF files that don't have a .nc extension fail to register.
3. Fixed the `/search` test parameters, which seemed to be out of date.
4. Remove an invalid comparison between access token and username
5. Add a test that checks various timestamp queries, as well as `filter_list`

Fixes #101
Fixes #102 
Fixes #103