### PR TITLE
Fix: Handle failure of dxspaces import properly

### DIFF
--- a/api/config/dxspaces_settings.py
+++ b/api/config/dxspaces_settings.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
         if have_staging:
             return(RegistrationTest(self.dxspaces_registration))
         else:
-            return(False)
+            return(RegistrationTest('none'))
 
     model_config = {
         "env_file": "./env_variables/.env_dxspaces",

--- a/api/services/url_services/add_url.py
+++ b/api/services/url_services/add_url.py
@@ -2,7 +2,6 @@ import json
 from api.config import ckan_settings, dxspaces_settings 
 from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type
 from api.services.default_services import log_retry_attempt
-import dxspaces
 
 # Define a set of reserved keys that should not be used in the extras
 RESERVED_KEYS = {'name', 'title', 'owner_org', 'notes', 'id', 'resources', 'collection', 'url', 'mapping', 'processing', 'file_type'}


### PR DESCRIPTION
Fixes #108 

Remove extraneous `import dxspaces` in `add_url.py` and sets `registration_methods` to a `RegistrationTest` that always returns `False`, instead of a literal False.